### PR TITLE
docs: session 27 — UI redesign + flyout + customer_id gap

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -3,7 +3,7 @@
 **Project:** BaySys Call Audit AI
 **Repo:** `Pilot1940/Baysys-AI-Call-Auditor` (backend) · `bsfg-finance/crm` branch `call-audit-frontend-embed` (UI)
 **Build start:** 2026-04-01
-**Last updated:** 2026-04-19 (Session 26 — CRM UI redesign, wine theme + 3-tab IA)
+**Last updated:** 2026-04-21 (Session 27 — Trainer-primitive adoption, compact filters, CallDrawer flyout)
 **Build method:** Claude Code (Opus 4.6)
 
 ---
@@ -32,6 +32,56 @@
 | **Q** | **OwnLLM Scoring Backend (designed, not yet executed)** | **2026-04-07** | — |
 | **R** | **OwnLLM Score UI swap (designed, not yet executed)** | **2026-04-07** | — |
 | **Session 26** | **CRM UI redesign — wine palette, 3-tab IA, privilege-gated Ops, review fixes applied** | **2026-04-20** | — |
+| **Session 27** | **Trainer Action Board primitives, compact column-header filters, CallDrawer flyout, customer_id search** | **2026-04-21** | crm #72, #73 merged, #74 open |
+
+---
+
+## Session 27 — Trainer-primitive adoption, compact filters, CallDrawer flyout
+
+**Date:** 2026-04-21
+**Scope:** Second UI pass on the `crm` production frontend to align the Call Audit surface with the Voice Trainer Action Board vocabulary, tighten the recordings triage flow, and replace the full-page call detail route with a right-side flyout. Backend untouched. All work shipped via three PRs on the `crm` repo.
+
+### Repos & branches
+- `bsfg-finance/crm` · base branch `master`
+- **PR #72** — `call-audit-frontend-embed` → `master` — MERGED. Topbar realignment (`490e1b1`) + Agents-tab Trainer-pattern primitives (`ed9d310`).
+- **PR #73** — `audit-ui/compact-filters-and-density` → `master` — MERGED. Compact filter row + denser Ops/Agents layout (`d47af1d`), drop View column row-click nav (`9632ca1`), filter chips folded into column headers (`1fe37df`).
+- **PR #74** — `audit-ui/call-flyout-and-customer-search` → `master` — OPEN. Customer ID filter (`839671b`), Call Detail flyout drawer (`2ccebfe`).
+
+### What shipped (UI)
+- **Trainer Action Board vocabulary** adopted across AgentsTab and AgentDrawer — new shared primitives `BandStatusPill`, `LevelBadge`, `ScoreBar`, `TrendArrow` co-located in `src/pages/audit/components/primitives.tsx` alongside the earlier `KpiCard` / `StatusPill` / `FatalBadge` / `ScoreCell` / `FilterChip` set.
+- **Compact filter row inside column headers** (RecordingsTab): status, agent_id, customer_id, date-range, FATAL ≥3, critical, unreviewed, score <50% chips all live under the column they filter. Old top-of-page filter bar removed.
+- **View column removed** — the whole row is now clickable/keyboard-navigable.
+- **OpsTab 2×2 tile grid** — denser layout, tighter spacing, no behavioural change.
+- **CallDrawer flyout** — replaces the full-page `/call-audit/call/:id` route with a right-side drawer (`src/pages/audit/components/CallDrawer.tsx`) mounted from `App.tsx`. Consistent with AgentDrawer (ESC to close, `role="dialog"`, `aria-modal`). Full-page route still exists for deep linking but Recordings table now opens the drawer by default.
+- **Customer ID search** added as a column-header filter (frontend-only — see backend gap below).
+
+### Backend gap (flagged, not fixed in this session)
+The recording list backend (`RecordingListView`) does NOT yet honour these query params, which the new UI sends:
+- `customer_id`
+- `fatal_level_gte`
+- `score_lt`
+- `has_critical_flags`
+- `has_unreviewed_flags`
+
+This affects both the production backend (`crm_apis` branch `call-auditor`, `arc/baysys_call_audit/views.py`) and the standalone reference repo (`Baysys-AI-Call-Auditor/baysys_call_audit/views.py`). A separate task has been spawned to wire these filters through the serializer/view + add tests. Until that lands, the frontend chips will appear to do nothing server-side.
+
+### Branch hygiene
+All three session PRs cleanly branched off `master`, merged or are open cleanly, and no stray local commits remain. `call-audit-frontend-embed` was used as the staging branch for PR #72 only — subsequent UI work correctly used dedicated `audit-ui/*` topic branches.
+
+### Files touched (crm repo)
+- `src/pages/audit/components/primitives.tsx` — new Trainer-pattern primitives.
+- `src/pages/audit/components/AgentsTab.tsx` — adopt BandStatusPill / LevelBadge / ScoreBar / TrendArrow; denser layout.
+- `src/pages/audit/components/AgentDrawer.tsx` — same primitive set; layout tightening.
+- `src/pages/audit/components/RecordingsTab.tsx` — column-header filters, drop View column, customer_id filter.
+- `src/pages/audit/components/OpsTab.tsx` — 2×2 tile grid.
+- `src/pages/audit/components/CallDrawer.tsx` — new flyout component (replaces page route usage).
+- `src/pages/audit/components/callDetailParts.tsx` — shared detail fragments used by both the drawer and the legacy full-page route.
+- `src/App.tsx` — drawer mount.
+
+### Docs
+- This `BUILD_LOG.md` entry.
+- `MANIFEST.md` updated — new primitives + `CallDrawer.tsx` + `callDetailParts.tsx` listed under "Production UI — `bsfg-finance/crm` repo".
+- `docs/OPERATIONS.md` — no change required (no route contract change from an ops perspective; the `/call-audit/call/:id` route still exists for deep linking).
 
 ---
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,7 +1,7 @@
 # BaySys Call Audit AI — Code Repository Manifest
 
 **Repo:** `Pilot1940/Baysys-AI-Call-Auditor`
-**Last updated:** Session 26 (2026-04-20 — CRM UI redesign ported to production `crm` repo, branch `call-audit-frontend-embed`, PR #68)
+**Last updated:** Session 27 (2026-04-21 — Trainer Action Board primitives, compact column-header filters, CallDrawer flyout; crm PRs #72, #73 merged, #74 open)
 **Test count:** 320 passing (standalone) · backend unchanged in this session
 **Ruff findings:** 0 (standalone) / 58 (crm_apis — auto-fixable)
 **Open issues:** TBD (issues created after push)
@@ -175,19 +175,21 @@
 
 ## Production UI — `bsfg-finance/crm` repo · branch `call-audit-frontend-embed`
 
-Ported in Session 14 (Prompt N), redesigned in Session 26 (Collexa wine theme).
+Ported in Session 14 (Prompt N), redesigned in Session 26 (Collexa wine theme), iterated in Session 27 (Trainer Action Board primitives + CallDrawer flyout).
 Files live under `crm/src/pages/audit/` and `crm/src/types/audit.ts`.
 
 | File (in crm repo) | Purpose |
 |---|---|
 | `src/pages/audit/AuditDashboardPage.tsx` | Top-level dashboard. Fetches `DashboardSummary`, derives KPIs + agency options, applies `Privilege.callAudit.edit()` gate, renders `AuditShell` with tab content. |
-| `src/pages/audit/AuditCallDetailPage.tsx` | 2-column detail view — audio, transcript (flag-evidence highlighting), compliance flag review, score hero, breakdown, call metadata. Uses `AUDIT_API.RECORDING_DETAIL/SIGNED_URL/RETRY/FLAG_REVIEW`. |
+| `src/pages/audit/AuditCallDetailPage.tsx` | Legacy full-page 2-column detail view (kept for deep linking). Session 27 added `CallDrawer` flyout that is now the default open-path from RecordingsTab. |
 | `src/pages/audit/components/AuditShell.tsx` | Page chrome: wine header, agency+period filter bar, tab strip. Props: `activeTab`, `agency`, `agencies`, `period`, `showOpsTab`. |
-| `src/pages/audit/components/primitives.tsx` | `KpiCard` (wine/amber/red/slate accents), `StatusPill`, `FatalBadge`, `ScoreCell`, `FilterChip`. |
-| `src/pages/audit/components/RecordingsTab.tsx` | Exception triage: FATAL ≥3 / score <50 / critical-flags / unreviewed chips + status/agent/date filters. Paged `RecordingListResponse`. |
-| `src/pages/audit/components/AgentsTab.tsx` | Sortable table (agent / calls / avg_score / fatals). Opens `AgentDrawer` on row click. |
-| `src/pages/audit/components/AgentDrawer.tsx` | Slide-in panel with Overview + Call History tabs. `role="dialog"`, ESC-to-close, `aria-modal`. |
-| `src/pages/audit/components/OpsTab.tsx` | Pipeline status + dry-run toggle + sync/submit/poll action cards. `canWrite` prop disables buttons. |
+| `src/pages/audit/components/primitives.tsx` | Session 26 set: `KpiCard` (wine/amber/red/slate accents), `StatusPill`, `FatalBadge`, `ScoreCell`, `FilterChip`. **Session 27 added** Trainer Action Board vocabulary: `BandStatusPill`, `LevelBadge`, `ScoreBar`, `TrendArrow`. |
+| `src/pages/audit/components/RecordingsTab.tsx` | Exception triage. **Session 27:** compact filter row lives inside column headers — status, agent_id, customer_id, date range, FATAL ≥3, critical, unreviewed, score <50%. View column removed; whole row clickable. |
+| `src/pages/audit/components/AgentsTab.tsx` | Sortable table (agent / calls / avg_score / fatals). Session 27 adopts Trainer primitives (BandStatusPill, LevelBadge, ScoreBar, TrendArrow) and denser layout. Opens `AgentDrawer` on row click. |
+| `src/pages/audit/components/AgentDrawer.tsx` | Slide-in panel with Overview + Call History tabs. Session 27 adopts the same Trainer primitive set. `role="dialog"`, ESC-to-close, `aria-modal`. |
+| `src/pages/audit/components/CallDrawer.tsx` | **Session 27** — right-side call-detail flyout that replaces the full-page route as the default open-path from RecordingsTab. Mounted from `App.tsx`. Consumes the shared fragments in `callDetailParts.tsx`. `role="dialog"`, ESC-to-close, `aria-modal`. |
+| `src/pages/audit/components/callDetailParts.tsx` | **Session 27** — shared detail sub-components (score hero, transcript with flag-evidence highlighting, flag review, metadata) consumed by both `CallDrawer` and the legacy `AuditCallDetailPage`. |
+| `src/pages/audit/components/OpsTab.tsx` | Pipeline status + dry-run toggle + sync/submit/poll action cards. Session 27 uses a 2×2 tile grid. `canWrite` prop disables buttons. |
 | `src/pages/audit/components/ScoreTrendChart.tsx` | Recharts LineChart with 85/70/55 band reference lines. Currently referenced for future per-call-score backend endpoint (not rendered in Session 26 — see H-1). |
 | `src/types/audit.ts` | TypeScript interfaces + helpers (`scoreBand`, `scoreBandLabel`, `formatDuration`, `formatDateTime`). |
 | `src/utils/auditAxios.ts` | Axios instance (baseURL = `${apiBase}/audit/${AUDIT_URL_SECRET}`, cookie + Bearer auth, 60s timeout). |
@@ -278,5 +280,6 @@ Files live under `crm/src/pages/audit/` and `crm/src/types/audit.ts`.
 | H-5 | HIGH | crm_apis `compliance.py` missing `_sync_content_hash()` | crm_apis mirror after Prompt Q |
 | H-6 | HIGH | crm_apis has 58 ruff errors from file mirror | `ruff check --fix` on crm_apis |
 | H-7 | HIGH | Timezone inconsistency: sync path explicit IST vs import path defaulting to UTC | `ingestion.py` |
+| H-8 | HIGH | `RecordingListView` does not honour `customer_id`, `fatal_level_gte`, `score_lt`, `has_critical_flags`, `has_unreviewed_flags` query params sent by the Session 27 UI filters (chips render but filter nothing server-side). Fix needed in both standalone `baysys_call_audit/views.py` and crm_apis `arc/baysys_call_audit/views.py`; separate task spawned 2026-04-21. | `views.py` + serializer + tests |
 | M-1 | MEDIUM | Batch size user input not validated in views | `views.py` |
 | M-2 | MEDIUM | `fetchall()` defeats batch_size memory protection | `ingestion.py` |


### PR DESCRIPTION
## Summary
Documentation catch-up for Session 27 UI work done in the CRM embed.

- **BUILD_LOG.md** — Session 27 entry (2026-04-21): Trainer action-board primitive adoption (BandStatusPill, LevelBadge, ScoreBar, TrendArrow), compact in-column-header filters on RecordingsTab, whole-row-clickable (View column removed), OpsTab 2×2 layout, CallDrawer flyout replacing the \`/call-audit/call/:id\` full-page route, Customer ID search filter added (frontend). PRs: crm#72 merged, crm#73 merged, crm#74 open.
- **MANIFEST.md** — new primitives + CallDrawer + callDetailParts catalogued under Production UI. Session 27 changes noted on RecordingsTab/AgentsTab/AgentDrawer/OpsTab. Known Issue **H-8** added: \`RecordingListView\` (both standalone and crm_apis call-auditor branch) silently ignores \`customer_id\`, \`fatal_level_gte\`, \`score_lt\`, \`has_critical_flags\`, \`has_unreviewed_flags\` — separate task spawned.

No code changes. Docs only.

## Branch hygiene audit (completed in this session)
Cross-repo scan confirmed **clean** across all 4 repos — no misplaced commits between Trainer and Auditor branches, no direct-to-master commits, no orphaned feature work. Full report in session transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)