### PR TITLE
docs: session 28 — agency grouping, Active Only toggle, inline ID pill

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -3,7 +3,7 @@
 **Project:** BaySys Call Audit AI
 **Repo:** `Pilot1940/Baysys-AI-Call-Auditor` (backend) · `bsfg-finance/crm` branch `call-audit-frontend-embed` (UI)
 **Build start:** 2026-04-01
-**Last updated:** 2026-04-21 (Session 27 — Trainer-primitive adoption, compact filters, CallDrawer flyout)
+**Last updated:** 2026-04-21 (Session 28 — Agents/Recordings agency grouping, Active Only toggle, inline ID pill)
 **Build method:** Claude Code (Opus 4.6)
 
 ---
@@ -33,6 +33,41 @@
 | **R** | **OwnLLM Score UI swap (designed, not yet executed)** | **2026-04-07** | — |
 | **Session 26** | **CRM UI redesign — wine palette, 3-tab IA, privilege-gated Ops, review fixes applied** | **2026-04-20** | — |
 | **Session 27** | **Trainer Action Board primitives, compact column-header filters, CallDrawer flyout, customer_id search** | **2026-04-21** | crm #72, #73 merged, #74 open |
+| **Session 28** | **Agents/Recordings agency grouping, Active Only toggle, inline agent-ID pill** | **2026-04-21** | crm #75 merged |
+
+---
+
+## Session 28 — Agents/Recordings agency grouping, Active Only toggle, inline ID pill
+
+**Date:** 2026-04-21
+**Scope:** Third UI pass on the `crm` production frontend. Agent and Recording tables now group by agency with a subtle header row, AgentsTab gets an "Active Only" default-on toggle with an "N active · M total" counter, and the agent cell collapses to a single line with a small slate pill for the agent ID. Backend untouched.
+
+### Repos & branches
+- `bsfg-finance/crm` · base branch `master`
+- **PR #75** — `audit-ui/agency-grouping-and-active-toggle` → `master` — MERGED.
+
+### What shipped (UI)
+- **AgentsTab**
+  - Dropped the serial-number (#) column.
+  - New **Active Only** wine pill in the header, default ON. "Active" is a frontend heuristic of `calls > 0` — no `is_active` field exists on `AgentSummaryRow` and no backend change was made.
+  - **N active · M total** counter rendered alongside the toggle.
+  - Rows grouped by `agency_id` with a subtle `bg-slate-50` group-header row (alphabetical, "Unassigned" last). In-group sort preserved.
+  - Inline agent-ID pill: Agent cell collapses to a single line with a small slate pill carrying the ID.
+- **RecordingsTab**
+  - Rows grouped by `agency_id` with the same subtle header pattern.
+  - Same inline agent-ID pill on the Agent cell.
+
+### Backend
+No change. PR #75 relied entirely on the existing `agency_id` field already on `AgentSummaryRow` / recording payloads. The H-8 gap (filter query params not honoured server-side) is unchanged and still open — unrelated to this session.
+
+### Files touched (crm repo)
+- `src/pages/audit/components/AgentsTab.tsx` — Active Only pill, counter, agency grouping, inline ID pill, # column removed.
+- `src/pages/audit/components/RecordingsTab.tsx` — agency grouping, inline ID pill.
+
+### Docs
+- This `BUILD_LOG.md` entry.
+- `MANIFEST.md` — AgentsTab/RecordingsTab rows updated to note Session 28 features.
+- `docs/OPERATIONS.md` — no change.
 
 ---
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,7 +1,7 @@
 # BaySys Call Audit AI — Code Repository Manifest
 
 **Repo:** `Pilot1940/Baysys-AI-Call-Auditor`
-**Last updated:** Session 27 (2026-04-21 — Trainer Action Board primitives, compact column-header filters, CallDrawer flyout; crm PRs #72, #73 merged, #74 open)
+**Last updated:** Session 28 (2026-04-21 — Agents/Recordings agency grouping, Active Only toggle, inline agent-ID pill; crm PR #75 merged)
 **Test count:** 320 passing (standalone) · backend unchanged in this session
 **Ruff findings:** 0 (standalone) / 58 (crm_apis — auto-fixable)
 **Open issues:** TBD (issues created after push)
@@ -175,7 +175,7 @@
 
 ## Production UI — `bsfg-finance/crm` repo · branch `call-audit-frontend-embed`
 
-Ported in Session 14 (Prompt N), redesigned in Session 26 (Collexa wine theme), iterated in Session 27 (Trainer Action Board primitives + CallDrawer flyout).
+Ported in Session 14 (Prompt N), redesigned in Session 26 (Collexa wine theme), iterated in Session 27 (Trainer Action Board primitives + CallDrawer flyout), and Session 28 (agency grouping + Active Only toggle + inline ID pill).
 Files live under `crm/src/pages/audit/` and `crm/src/types/audit.ts`.
 
 | File (in crm repo) | Purpose |
@@ -184,8 +184,8 @@ Files live under `crm/src/pages/audit/` and `crm/src/types/audit.ts`.
 | `src/pages/audit/AuditCallDetailPage.tsx` | Legacy full-page 2-column detail view (kept for deep linking). Session 27 added `CallDrawer` flyout that is now the default open-path from RecordingsTab. |
 | `src/pages/audit/components/AuditShell.tsx` | Page chrome: wine header, agency+period filter bar, tab strip. Props: `activeTab`, `agency`, `agencies`, `period`, `showOpsTab`. |
 | `src/pages/audit/components/primitives.tsx` | Session 26 set: `KpiCard` (wine/amber/red/slate accents), `StatusPill`, `FatalBadge`, `ScoreCell`, `FilterChip`. **Session 27 added** Trainer Action Board vocabulary: `BandStatusPill`, `LevelBadge`, `ScoreBar`, `TrendArrow`. |
-| `src/pages/audit/components/RecordingsTab.tsx` | Exception triage. **Session 27:** compact filter row lives inside column headers — status, agent_id, customer_id, date range, FATAL ≥3, critical, unreviewed, score <50%. View column removed; whole row clickable. |
-| `src/pages/audit/components/AgentsTab.tsx` | Sortable table (agent / calls / avg_score / fatals). Session 27 adopts Trainer primitives (BandStatusPill, LevelBadge, ScoreBar, TrendArrow) and denser layout. Opens `AgentDrawer` on row click. |
+| `src/pages/audit/components/RecordingsTab.tsx` | Exception triage. Session 27: compact filter row lives inside column headers — status, agent_id, customer_id, date range, FATAL ≥3, critical, unreviewed, score <50%. View column removed; whole row clickable. **Session 28:** rows grouped by `agency_id` with subtle `bg-slate-50` header row; inline agent-ID pill (single-line Agent cell with small slate ID pill). |
+| `src/pages/audit/components/AgentsTab.tsx` | Sortable table (agent / calls / avg_score / fatals). Session 27 adopts Trainer primitives (BandStatusPill, LevelBadge, ScoreBar, TrendArrow) and denser layout. Opens `AgentDrawer` on row click. **Session 28:** # column dropped; "Active Only" wine pill in the header (default ON, `calls > 0` heuristic — no `is_active` field exists); "N active · M total" counter; rows grouped by `agency_id` (alphabetical, "Unassigned" last) with in-group sort preserved; inline agent-ID pill. |
 | `src/pages/audit/components/AgentDrawer.tsx` | Slide-in panel with Overview + Call History tabs. Session 27 adopts the same Trainer primitive set. `role="dialog"`, ESC-to-close, `aria-modal`. |
 | `src/pages/audit/components/CallDrawer.tsx` | **Session 27** — right-side call-detail flyout that replaces the full-page route as the default open-path from RecordingsTab. Mounted from `App.tsx`. Consumes the shared fragments in `callDetailParts.tsx`. `role="dialog"`, ESC-to-close, `aria-modal`. |
 | `src/pages/audit/components/callDetailParts.tsx` | **Session 27** — shared detail sub-components (score hero, transcript with flag-evidence highlighting, flag review, metadata) consumed by both `CallDrawer` and the legacy `AuditCallDetailPage`. |


### PR DESCRIPTION
## Summary
- Logs crm PR #75 as Session 28 in `BUILD_LOG.md` — AgentsTab drops the # column, adds an "Active Only" default-on pill (calls>0 heuristic) with an "N active · M total" counter, groups rows by `agency_id` (alphabetical, "Unassigned" last); RecordingsTab adopts the same agency grouping; both tables get an inline agent-ID pill.
- `MANIFEST.md` AgentsTab + RecordingsTab rows updated with the Session 28 features. Header bumped.
- Backend untouched. H-8 filter gap unchanged.

## Test plan
- [ ] Read-only doc review — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)