### PR TITLE
feat(api): expose agency_name on recording list and agent summary

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -873,3 +873,39 @@ Replaced `while True: fetchmany()` loop with a single `cursor.fetchall()` inside
 3. **`call_counts_cache` is optional** — defaults to None. CSV/Excel import callers pass nothing; behaviour unchanged.
 
 ### Test count: 271 passing, 0 ruff findings (commit: 55fd923)
+
+---
+
+## Session 29 — 2026-04-22: expose `agency_name` on list + summary APIs
+
+### Goal
+
+Frontend group headers in `AgentsTab` and `RecordingsTab` currently render raw `agency_id`
+(e.g. `"8"`). UI needed a readable name (e.g. `"Prolynk"`) without leaking CRM models
+outside `crm_adapter.py`.
+
+### Changes
+
+- `baysys_call_audit/crm_adapter.py` — new `get_agency_name_map(agency_ids) -> dict[str, str]`.
+  Mock returns a fixed `{"1": "BaySys Collections", "2": "Metro Recovery", "3": "National ARC"}`
+  map. Prod does one batched `Agency.objects.filter(agency_id__in=…).values(…)` query with
+  CRM import scoped inside the function body (`# noqa: PLC0415`). Unknown ids are absent
+  from the returned map — callers treat as "name unknown".
+- `baysys_call_audit/views.py` — `RecordingListView.get()` post-processes the serializer
+  output: collect distinct non-null `agency_id`s, single adapter call, inject
+  `agency_name` (nullable string) on each row. Same treatment in
+  `DashboardSummaryView.get()` — `agent_summary` aggregation now includes `agency_id`
+  and each row gets `agency_name` injected.
+- `baysys_call_audit/tests/test_views.py` — new `AgencyNameEnrichmentTests` class with
+  two tests covering both endpoints, including null and unknown-agency fallbacks. Uses
+  `force_authenticate(MockUser(role_id=1))` to bypass the agency-scoped RBAC filter so
+  multi-agency rows are visible.
+
+### Shape notes
+
+- `CallRecording.agency_id` is a raw `CharField` (no FK). The adapter normalises keys to
+  strings to keep the lookup side-agnostic.
+- `DashboardSummarySerializer.agent_summary` is declared as `ListField(child=DictField())`,
+  so the added `agency_name` key passes through with no serializer change.
+
+### Test count: 322 passing, 0 ruff findings

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,8 +1,8 @@
 # BaySys Call Audit AI — Code Repository Manifest
 
 **Repo:** `Pilot1940/Baysys-AI-Call-Auditor`
-**Last updated:** Session 27 (2026-04-21 — Trainer Action Board primitives, compact column-header filters, CallDrawer flyout; crm PRs #72, #73 merged, #74 open)
-**Test count:** 320 passing (standalone) · backend unchanged in this session
+**Last updated:** Session 29 (2026-04-22 — expose `agency_name` on recording list + agent summary responses for UI group headers)
+**Test count:** 322 passing (standalone) · +2 tests for agency-name enrichment
 **Ruff findings:** 0 (standalone) / 58 (crm_apis — auto-fixable)
 **Open issues:** TBD (issues created after push)
 **Production UI lives in:** `bsfg-finance/crm` repo, branch `call-audit-frontend-embed`. The `baysys_call_audit_ui/` scaffold in this repo is reference-only.
@@ -129,7 +129,7 @@
 | `apps.py` | AppConfig | name=`baysys_call_audit`, verbose_name=`BaySys Call Audit AI` |
 | `admin.py` | Django admin registrations | All 5 models registered with list_display, filters, search |
 | `auth.py` | Authentication + RBAC | `MockUser`, `MockCrmAuth`, `get_auth_backend()`, `AuditPermissionMixin` |
-| `crm_adapter.py` | CRM mock/prod seam | `get_auth_backend_name()`, `get_user_portfolio()`, `get_team_users()`, `get_user_agency_id()`, `get_agency_list()`, `get_user_names()`, `get_signed_url()` |
+| `crm_adapter.py` | CRM mock/prod seam | `get_auth_backend_name()`, `get_user_portfolio()`, `get_team_users()`, `get_user_agency_id()`, `get_agency_list()`, `get_agency_name_map()`, `get_user_names()`, `get_signed_url()` |
 | `speech_provider.py` | Provider adapter | `submit_recording()`, `get_results()`, `delete_resource()`, `ask_question()`, `submit_transcript()`, `update_metadata()`, `ProviderError`. Session 25: `data=` → `json=` payload fix, `details[0]` unwrap from GreyLabs response, `customer_id` in submit payload. |
 | `compliance.py` | Config-driven compliance engine | `check_metadata_compliance(recording, call_counts_cache=None)` — cache dict enables O(1) max_calls check (sync path); None falls back to DB query (webhook path). `check_provider_compliance()`, `compute_fatal_level()`, `load_compliance_rules()`, `load_fatal_level_rules()`, `load_gazette_holidays()`, `_sync_content_hash()` (standalone only — auto-updates YAML content hash with warning). All time/date checks use IST via `_IST = ZoneInfo("Asia/Kolkata")`. `lru_cache` on YAML loaders — requires restart to pick up config changes. |
 | `ingestion.py` | Shared ingestion logic | `create_recording_from_row(row, existing_urls=None, call_counts_cache=None)` — `existing_urls` set: O(1) dedup; `call_counts_cache` dict: O(1) max_calls check. Both default to None (CSV/webhook paths use DB fallback). `run_sync_for_date()` — pre-fetches existing URLs (one query) and call counts dict (one annotated query) before loop; uses `fetchall()` to drain cursor before ORM writes (pgbouncer transaction-mode safe); `bulk_create()` for batch inserts (was N individual ORM creates). `validate_row()`, `parse_datetime_flexible()`, `normalize_column_name()`, `_determine_submission_tier()`, `_load_submission_priority()`. SYNC_QUERY filters on `call_start_time`; duration from `SYNC_MIN_CALL_DURATION` (default 20s). Session 25: IST timezone fix in `run_sync_for_date()`. Session 25 cont.: IST fix also applied to `create_recording_from_row()` — `make_aware()` now explicitly uses `ZoneInfo("Asia/Kolkata")` on both code paths. |

--- a/baysys_call_audit/crm_adapter.py
+++ b/baysys_call_audit/crm_adapter.py
@@ -110,6 +110,47 @@ def get_signed_url(s3_path: str) -> str:
     return s3_download(s3_path)
 
 
+def get_agency_name_map(agency_ids) -> dict[str, str]:
+    """
+    Map agency_ids -> agency_name. Accepts any iterable of agency_ids.
+    Keys in the returned dict are always stringified agency_ids so callers can
+    look up regardless of how the ID is stored (CallRecording.agency_id is CharField).
+
+    Mock: returns a fixed fixture covering the dev agency IDs used elsewhere.
+    Prod: a single Agency.objects.filter(id__in=...) query.
+    Unknown agency_ids are simply absent from the returned map — callers should
+    treat a missing key as "name unknown".
+    """
+    ids = {str(a) for a in agency_ids if a is not None and str(a).strip() != ""}
+    if not ids:
+        return {}
+
+    if get_auth_backend_name() == "mock":
+        mock_map = {
+            "1": "BaySys Collections",
+            "2": "Metro Recovery",
+            "3": "National ARC",
+        }
+        return {aid: mock_map[aid] for aid in ids if aid in mock_map}
+
+    from arc.crm.models.agency_model import Agency  # noqa: PLC0415
+    # Agency ids in CRM are integers; coerce defensively and skip non-numeric.
+    numeric_ids: list[int] = []
+    for aid in ids:
+        try:
+            numeric_ids.append(int(aid))
+        except (TypeError, ValueError):
+            continue
+    if not numeric_ids:
+        return {}
+    return {
+        str(row["agency_id"]): row["agency_name"]
+        for row in Agency.objects.filter(agency_id__in=numeric_ids).values(
+            "agency_id", "agency_name",
+        )
+    }
+
+
 def get_user_names(user_ids: list[int]) -> dict[int, str]:
     """
     Map user_ids -> display name ('First Last').

--- a/baysys_call_audit/tests/test_views.py
+++ b/baysys_call_audit/tests/test_views.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient, APIRequestFactory
 
+from baysys_call_audit.auth import MockUser
 from baysys_call_audit.models import (
     CallRecording,
     CallTranscript,
@@ -194,6 +195,44 @@ class DashboardSummaryExtendedTests(TestCase):
         self.assertEqual(len(summary), 2)
         # Highest avg_score first
         self.assertEqual(summary[0]["agent_id"], "A001")
+
+
+class AgencyNameEnrichmentTests(TestCase):
+    """agency_name injection on the recording list and agent summary endpoints."""
+
+    def setUp(self):
+        self.client = APIClient()
+        # Force an Admin (cross-agency) mock user so rows spanning multiple
+        # agency_ids are visible.
+        self.client.force_authenticate(user=MockUser(role_id=1))
+        self.list_url = reverse("baysys_call_audit:recording-list")
+        self.summary_url = reverse("baysys_call_audit:dashboard-summary")
+
+    def test_recording_list_includes_agency_name(self):
+        _make_recording(agency_id="1")
+        _make_recording(agent_id="A002", agency_id="2")
+        _make_recording(agent_id="A003", agency_id="999")  # unknown -> None
+        _make_recording(agent_id="A004", agency_id=None)   # null -> None
+        resp = self.client.get(self.list_url)
+        self.assertEqual(resp.status_code, 200)
+        by_agent = {r["agent_id"]: r for r in resp.data["results"]}
+        self.assertEqual(by_agent["A001"]["agency_name"], "BaySys Collections")
+        self.assertEqual(by_agent["A002"]["agency_name"], "Metro Recovery")
+        self.assertIsNone(by_agent["A003"]["agency_name"])
+        self.assertIsNone(by_agent["A004"]["agency_name"])
+
+    def test_agent_summary_includes_agency_name(self):
+        r1 = _make_recording(agent_id="A001", agent_name="Alice",
+                             agency_id="1", status="completed")
+        r2 = _make_recording(agent_id="A002", agent_name="Bob",
+                             agency_id="2", status="completed")
+        ProviderScore.objects.create(recording=r1, template_id="T1", score_percentage=90.0)
+        ProviderScore.objects.create(recording=r2, template_id="T1", score_percentage=60.0)
+        resp = self.client.get(self.summary_url)
+        self.assertEqual(resp.status_code, 200)
+        by_agent = {row["agent_id"]: row for row in resp.data["agent_summary"]}
+        self.assertEqual(by_agent["A001"]["agency_name"], "BaySys Collections")
+        self.assertEqual(by_agent["A002"]["agency_name"], "Metro Recovery")
 
 
 class RecordingSignedUrlViewTests(TestCase):

--- a/baysys_call_audit/views.py
+++ b/baysys_call_audit/views.py
@@ -145,8 +145,15 @@ class RecordingListView(AuditPermissionMixin, APIView):
         total = qs.count()
 
         serializer = CallRecordingListSerializer(qs[start:end], many=True)
+        results = list(serializer.data)
+        # Enrich with human-readable agency names via the CRM adapter (single batched lookup).
+        agency_ids = {row.get("agency_id") for row in results if row.get("agency_id")}
+        agency_name_map = crm_adapter.get_agency_name_map(agency_ids) if agency_ids else {}
+        for row in results:
+            aid = row.get("agency_id")
+            row["agency_name"] = agency_name_map.get(str(aid)) if aid else None
         return Response({
-            "results": serializer.data,
+            "results": results,
             "pagination": {
                 "page": page,
                 "page_size": page_size,
@@ -221,7 +228,7 @@ class DashboardSummaryView(AuditPermissionMixin, APIView):
 
         agent_summary = list(
             qs.filter(status="completed")
-            .values("agent_id", "agent_name")
+            .values("agent_id", "agent_name", "agency_id")
             .annotate(
                 calls=Count("pk"),
                 avg_score=Avg("provider_scores__score_percentage"),
@@ -229,6 +236,12 @@ class DashboardSummaryView(AuditPermissionMixin, APIView):
             )
             .order_by("-avg_score")[:20]
         )
+        # Enrich with human-readable agency names (one batched adapter lookup).
+        agency_ids = {row.get("agency_id") for row in agent_summary if row.get("agency_id")}
+        agency_name_map = crm_adapter.get_agency_name_map(agency_ids) if agency_ids else {}
+        for row in agent_summary:
+            aid = row.get("agency_id")
+            row["agency_name"] = agency_name_map.get(str(aid)) if aid else None
 
         data = {
             "total_recordings": total,


### PR DESCRIPTION
## Summary
- New `crm_adapter.get_agency_name_map(agency_ids) -> dict[str, str]` — the sole CRM seam for agency name lookups. Mock returns a 3-entry fixture; prod does one batched `Agency.objects.filter(agency_id__in=...)` query with the import scoped inside the function (`# noqa: PLC0415`).
- `RecordingListView` and `DashboardSummaryView.agent_summary` now inject a nullable `agency_name` into every row using one batched adapter call per request. Unknown or null `agency_id`s resolve to `None`.
- Pairs with crm_apis PR `audit/expose-agency-name` and frontend PR `audit-ui/agency-name-headers` on `bsfg-finance/crm`.

## Test plan
- [x] `python manage.py test --settings=settings_test baysys_call_audit -v 0` — 322 passing (+2 new)
- [x] `python -m ruff check baysys_call_audit/` — 0 findings
- [x] New `AgencyNameEnrichmentTests` covers both endpoints including null + unknown-agency fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)